### PR TITLE
It Takes a Village: Village List Styling 2.0

### DIFF
--- a/src/components/dialog/CreateVillageForm.js
+++ b/src/components/dialog/CreateVillageForm.js
@@ -166,7 +166,7 @@ export const CreateVillageForm = props => {
                         }
                         <Form.Group id="buttonContainer">
                             {budgetState.length === 0 ? <Button onClick={(e) => { addBudgetExpense(e) }}>Add a monthly pledge</Button> : ""}
-                            {budgetState.length === 1 ? <Button onClick={(e) => { addBudgetExpense(e) }}>Add another monthly pledge</Button> : ""}
+                            {budgetState.length !== 0 && budgetState.length < 9 ? <Button onClick={(e) => { addBudgetExpense(e) }}>Add another monthly pledge</Button> : ""}
                             <Button type="submit">Create village</Button>
                         </Form.Group>
                     </Form>

--- a/src/components/dialog/EditBudgetForm.js
+++ b/src/components/dialog/EditBudgetForm.js
@@ -70,7 +70,6 @@ export const EditBudgetForm = props => {
     }
 
     const editVillageBudget = () => {
-        
         const deleteBudgetObjects = () => {
             for (const budgetObject of deleteBudgetState) {
                 deleteBudget(budgetObject.id)

--- a/src/components/dialog/EditPledgeForm.js
+++ b/src/components/dialog/EditPledgeForm.js
@@ -39,7 +39,7 @@ export const EditPledgeForm = props => {
         const proptery = greatGrandparent.children[0].children[1].value
         const value = parseInt(greatGrandparent.children[1].children[1].value)
 
-        if (typeof e.target.value !== "") {
+        if (e.target.value !== "") {
             if (Number.isNaN(value)) {
                 delete foundObject.amount
                 delete foundObject.hours

--- a/src/components/dialog/RSVPEventDialog.js
+++ b/src/components/dialog/RSVPEventDialog.js
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useEffect } from "react"
+import React, { useContext, useState } from "react"
 import emailjs from 'emailjs-com'
 import Button from "react-bootstrap/Button"
 import Col from 'react-bootstrap/Col'

--- a/src/components/village/Village.css
+++ b/src/components/village/Village.css
@@ -57,13 +57,30 @@
     display: none;
 }
 
+.homeList {
+    background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.5), #FFFFFF 35%);
+}
+
+.previewCard__Container {
+    margin: 2rem 0rem;
+}
+
+.previewCard__Container h5 {
+    display: table-caption;
+    font-size: 3rem;
+    position: relative;
+    top: 75px;
+    writing-mode: vertical-lr;
+}
+
 .previewCard__containerUnhidden {
     background-image: linear-gradient(to bottom, #76b852, #8DC26F, #FFFFFF);
     border-radius: 2.5%;
+    width: 85%;
 }
 
 [id^='hiddenCard--'] {
-    margin-left: 3rem;
+    margin-left: 4rem;
 }
 
 [id^='previewCard--'] {
@@ -86,7 +103,7 @@
 [id^='previewList--'] {
     list-style-type: none;
     display: block;
-    margin: 2rem 33%;
+    margin: 2rem 34%;
     text-align: center;
     width: 210px;
 }
@@ -104,26 +121,25 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: space-around;
+    padding: 0rem 4rem;
+}
+
+.villageList__header {
+    background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url("https://fulleryouthinstitute.org/assets/fyi-files/Effective_Homeless_Ministry.jpg");
+    background-repeat: no-repeat;
+    background-size: cover;
+    height: 25rem;
     padding: 5rem;
 }
 
-.villageListContainer {
-    margin-top: 100px;
-}
-
-.villageContainer h1 {
-    margin-top: 2rem;
+.villageList__text {
+    color: white;
+    left: 50%;
     text-align: center;
-}
-
-.villageListContainer__header {
-    margin-top: 30px;
-    text-align: center;
-}
-
-.villageListContainer__header > * {
-    margin-top: 30px;
-    text-align: center;
+    position: absolute;
+    top: 15rem;
+    transform: translate(-50%, -50%);
+    width: max-content;
 }
 
 .green {
@@ -157,4 +173,34 @@
 .color-keyContainer {
     display: flex;
     flex-wrap: nowrap;
+}
+#featuredVillage {
+    background-image: linear-gradient(to bottom, goldenrod, gold, white);
+    border-radius: 2.5%;
+    width: 85%;
+}
+
+[data-title]:hover:after {
+    opacity: 1;
+    transition: all 0.1s ease 0.5s;
+    visibility: visible;
+}
+[data-title]:after {
+    background-color: #1c92d2;
+    border: 1px solid #111111;
+    box-shadow: 1px 1px 3px #222222;
+    color: black;
+    content: attr(data-title);
+    font-size: 150%;
+    left: 20%;
+    opacity: 0;
+    padding: 1px 5px 2px 5px;
+    position: absolute;
+    bottom: -2em;
+    visibility: hidden;
+    white-space: nowrap;
+    z-index: 99999;
+}
+[data-title] {
+    position: relative;
 }

--- a/src/components/village/VillageList.js
+++ b/src/components/village/VillageList.js
@@ -15,16 +15,49 @@ export const VillageList = props => {
     const currentUser = props.userId
     const home = props.home
 
-    const villagesArrayCopy = villages.slice()
-    villagesArrayCopy.map(v => {
-        let villageRelationship = villageUsers.find(vu => vu.userId === currentUser && vu.protege === false && v.id === vu.villageId) || {}
+    villages.map(v => {
+        const villageRelationship = villageUsers.find(vu => vu.userId === currentUser && v.id === vu.villageId) || {}
         if (villageRelationship.protege === false) {
             v.patron = true
+        } else if (villageRelationship.protege) {
+            v.protege = true
         } else {
             v.protege = false
         }
     })
-    const patronedVillageArray = villagesArrayCopy.filter(v => v.patron === true)
+
+    const patronedVillageArray = villages.filter(v => v.patron === true)
+
+    const nonMemberVillages = villages.filter((v) => !v.patron && !v.protege)
+
+    const randomIndex = Math.floor(Math.random() * nonMemberVillages.length)
+
+    if (nonMemberVillages.length !== 0) {
+        for (const village of villages) {
+            delete village.featuredVillage
+        }
+
+        const feature = nonMemberVillages[randomIndex]
+        feature.featuredVillage = true
+
+        nonMemberVillages.sort((currentObject, nextObject) => {
+            const currentVillage = currentObject.lastName;
+            const nextVillage = nextObject.lastName;
+
+            if (currentVillage < nextVillage) {
+                return -1
+            }
+            if (currentVillage > nextVillage) {
+                return 1
+            }
+            return 0
+        })
+
+        if (randomIndex > 0) {
+            nonMemberVillages.splice(randomIndex, 1)
+            nonMemberVillages.unshift(feature)
+        }
+    }
 
     const [budgetState, setBudgetState] = useState([])
 
@@ -56,12 +89,15 @@ export const VillageList = props => {
 
     return (
         <section className="villageListContainer">
-            <div className="villageListContainer__header">
-                {home ? <h1>Visit a village to volunteer!</h1> : ""}
-                {home ? <Button id="villageList--button" variant="primary" onClick={toggle}>Create a village</Button> : ""}
-            </div>
-            <section className="villageList">
-                {home ? List(villages) : List(patronedVillageArray)}
+            {home ? <div className="villageList__header">
+                <div className="villageList__text">
+                    <h1>Click on a photo to see a user's description,<br /> and visit their village to volunteer<br /> OR<br /></h1>
+                    <Button id="villageList--button" variant="primary" size="lg" onClick={toggle}>Create a new village</Button>
+                </div>
+            </div> : ""}
+
+            <section className={home ? 'villageList homeList' : 'villageList'}>
+                {home ? List(nonMemberVillages) : List(patronedVillageArray)}
             </section>
 
             <CreateVillageForm

--- a/src/components/village/VillagePreview.js
+++ b/src/components/village/VillagePreview.js
@@ -24,31 +24,37 @@ export const VillagePreview = (props) => {
     filteredTreasurePledges.map(tp => pledgeTotal = pledgeTotal + tp.amount)
 
     return (
-        <div className="previewCard__Container">
+        <div className='previewCard__Container' id={village.featuredVillage ? 'featuredVillage' : ''}>
+            {village.featuredVillage ? <h5>Featured Village</h5> : ''}
             <div id={`previewCard--${protege.id}`} onClick={(e) => {
-                if (e.target.id) {
-                    if (e.target.id.includes("previewImg--")) {
-                        const grandparentElement = e.target.parentElement.parentElement
-                        const hiddenDivBoolean = grandparentElement.children[1].classList.contains("hidden")
-                        if (hiddenDivBoolean) {
-                            grandparentElement.children[1].classList.remove("hidden")
-                            grandparentElement.scrollIntoView({
-                                behavior: "smooth",
-                                block: "center"
-                            })
-                            grandparentElement.parentElement.classList.add("previewCard__containerUnhidden")
-                        } else {
-                            grandparentElement.children[1].classList.add("hidden")
-                            grandparentElement.parentElement.classList.remove("previewCard__containerUnhidden")
+                if (!village.featuredVillage) {
+                    if (e.target.id) {
+                        if (e.target.id.includes("previewImg--")) {
+                            if (village.patron === true) {
+                                villageLink(village.id)
+                            } else {
+                                const grandparentElement = e.target.parentElement.parentElement
+                                const hiddenDivBoolean = grandparentElement.children[1].classList.contains("hidden")
+                                if (hiddenDivBoolean) {
+                                    grandparentElement.children[1].classList.remove("hidden")
+                                    grandparentElement.scrollIntoView({
+                                        behavior: "smooth",
+                                        block: "center"
+                                    })
+                                    grandparentElement.parentElement.classList.add("previewCard__containerUnhidden")
+                                } else {
+                                    grandparentElement.children[1].classList.add("hidden")
+                                    grandparentElement.parentElement.classList.remove("previewCard__containerUnhidden")
+                                }
+                            }
                         }
-
                     }
                 }
             }}>
-                <div>
+                <div data-title={village.patron ? `${protege.firstName} ${protege.lastName}` : null}>
                     <img id={`previewImg--${protege.id}`} src={`${protege.image}`} alt="smiley face" />
                 </div>
-                <div id={`hiddenCard--${protege.id}`} className="hidden">
+                <div id={`hiddenCard--${protege.id}`} className={village.featuredVillage ? null : 'hidden'} data-title={village.featuredVillage ? null : `Click photo again to minimize`}>
                     <p id={`previewTitle--${protege.id}`}>{protege.firstName} {protege.lastName}'s Village</p>
                     <p id={`previewText--${protege.id}`}>{village.description}</p>
                     <ul id={`previewList--${protege.id}`}>


### PR DESCRIPTION
### Comments:
- Added styling to village list home and patron views.
- Added a featured village banner at the top of the home screen that shows a featured village from all villages that the user is not a member of.
- Added a hero image banner to the home village list.
- Added a limit to the number of budget items that can be created for each village to nine.
- Added a limit to the number of pledges a village member can promise to two, as there are currently only time and treasure pledges available.
- Added a click event that now toggles the village info banner on the preview cards.
- Added a click event on the preview card for villages that the user already belongs to that skips the banner and takes them directly to the village home page.